### PR TITLE
Revert "allow build and test action to be triggered manually"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
there is no reason to have it manually trigger-able

- related to #41 